### PR TITLE
Fixed android priority

### DIFF
--- a/src/rides/notify.ts
+++ b/src/rides/notify.ts
@@ -57,7 +57,7 @@ const sendAndroidNotification = async (payload: NotificationPayload, logger: Log
       nextStationId: payload.state.nextStationId.toString(),
     },
     android: {
-      priority: payload.shouldSendImmediately ? "high" : "normal",
+      priority: "high",
     },
   }
 


### PR DESCRIPTION
To send data notifications when app is quit the priority on android should be set to `high`