### PR TITLE
Added iOS stale date

### DIFF
--- a/src/rides/notify.ts
+++ b/src/rides/notify.ts
@@ -25,6 +25,7 @@ const sendAppleNotification = async (payload: NotificationPayload, logger: Logge
     timestamp: dayjs().unix(),
     event: payload.state.status === Status.arrived ? "end" : "update",
     "content-state": payload.state,
+    "stale-date": payload.state.status !== Status.arrived && dayjs().add(135, "seconds").unix(),
     "dismissal-date": payload.state.status === Status.arrived && dayjs().add(3, "minutes").unix(),
     alert: payload.alert && {
       title: payload.alert.title,


### PR DESCRIPTION
Mark Live Activity state as invalid if the user's device didn't recieve notifications for more than 2 minutes.