### PR TITLE
Always push dismissal date

### DIFF
--- a/src/rides/scheduler.ts
+++ b/src/rides/scheduler.ts
@@ -222,7 +222,7 @@ export class Scheduler {
    */
   private async sendNotification(notification: NotificationPayload) {
     if (!this.lastSentNotification || notification.id >= this.lastSentNotification?.id) {
-      await sendNotification(notification, this.logger)
+      await sendNotification(notification, this.route, this.logger)
 
       this.notificationsToSend = this.notificationsToSend.filter((notificationToSend) => notificationToSend.id > notification.id)
       if (isEmpty(this.notificationsToSend)) {


### PR DESCRIPTION
Always push Live Activity dismissal date to avoid stale rides when there're connection issues long after the train arrived.